### PR TITLE
bugfix(develop): trying different approach with if condition in queue_release job

### DIFF
--- a/.github/workflows/workflow_distribution.yml
+++ b/.github/workflows/workflow_distribution.yml
@@ -465,16 +465,18 @@ jobs:
   #####################################################################
   queue_release:
     runs-on: ubuntu-22.04
-    # Simplified to focus on merge events only
-    if: |
-      success() && 
-      github.event_name == 'pull_request' &&
-      github.event.pull_request.merged == true &&
-      (
-        (github.event.pull_request.base.ref == 'beta' && github.event.pull_request.head.ref == 'develop') ||
-        (github.event.pull_request.base.ref == 'main' && github.event.pull_request.head.ref == 'beta')
-      )
     needs: [setup_docker, e2e_tests, security_scan]
+    if: |
+      (
+        github.event_name == 'pull_request' &&
+        github.event.pull_request.merged == true &&
+        (
+          (github.event.pull_request.base.ref == 'beta' && github.event.pull_request.head.ref == 'develop') ||
+          (github.event.pull_request.base.ref == 'main' && github.event.pull_request.head.ref == 'beta')
+        )
+      ) &&
+      !contains(needs.*.result, 'failure') &&
+      !contains(needs.*.result, 'cancelled')
     steps:
       # Add debug logging first
       - name: Debug Event Info


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes an important change to the `queue_release` job in the `.github/workflows/workflow_distribution.yml` file. The change focuses on improving the conditions under which the job runs by refining the logic for checking merge events and ensuring that all dependent jobs have succeeded.

Improvements to job conditions:

* [`.github/workflows/workflow_distribution.yml`](diffhunk://#diff-eadded3b2f326acf5e7f0e7d84f09ce02fe476b9d81433f379417cd5bcc002e2L468-R479): Updated the `if` condition to ensure that the `queue_release` job only runs if all dependent jobs (`setup_docker`, `e2e_tests`, `security_scan`) have succeeded and none have failed or been cancelled.