### PR TITLE
bugfix(develop): adding notify_success job to dep array for queue_release job

### DIFF
--- a/.github/workflows/workflow_distribution.yml
+++ b/.github/workflows/workflow_distribution.yml
@@ -465,43 +465,35 @@ jobs:
   #####################################################################
   queue_release:
     runs-on: ubuntu-22.04
-    needs: [setup_docker, e2e_tests, security_scan]
+    # Add notify_success to needs array to ensure all checks have passed
+    needs: [setup_docker, e2e_tests, security_scan, notify_success]
     if: |
+      success() &&
+      github.event_name == 'pull_request' &&
+      github.event.action == 'closed' &&
+      github.event.pull_request.merged == true &&
       (
-        github.event_name == 'pull_request' &&
-        github.event.pull_request.merged == true &&
-        (
-          (github.event.pull_request.base.ref == 'beta' && github.event.pull_request.head.ref == 'develop') ||
-          (github.event.pull_request.base.ref == 'main' && github.event.pull_request.head.ref == 'beta')
-        )
-      ) &&
-      !contains(needs.*.result, 'failure') &&
-      !contains(needs.*.result, 'cancelled')
+        (github.event.pull_request.base.ref == 'beta' && github.event.pull_request.head.ref == 'develop') ||
+        (github.event.pull_request.base.ref == 'main' && github.event.pull_request.head.ref == 'beta')
+      )
     steps:
-      # Add debug logging first
       - name: Debug Event Info
         run: |
           echo "=== Debug Info ==="
           echo "Event name: ${{ github.event_name }}"
+          echo "Event action: ${{ github.event.action }}"
           echo "PR merged: ${{ github.event.pull_request.merged }}"
           echo "Base ref: ${{ github.event.pull_request.base.ref }}"
           echo "Head ref: ${{ github.event.pull_request.head.ref }}"
+          echo "Job status: ${{ job.status }}"
+          echo "Needs status:"
+          echo "  setup_docker: ${{ needs.setup_docker.result }}"
+          echo "  e2e_tests: ${{ needs.e2e_tests.result }}"
+          echo "  security_scan: ${{ needs.security_scan.result }}"
+          echo "  notify_success: ${{ needs.notify_success.result }}"
           echo "=================="
       - uses: actions/checkout@v4
       
-      # Enhanced debug logging
-      - name: Debug Event Info
-        run: |
-          echo "Event name: ${{ github.event_name }}"
-          echo "Event action: ${{ github.event.action }}"
-          echo "Ref: ${{ github.ref }}"
-          echo "Base ref: ${{ github.event.pull_request.base.ref }}"
-          echo "Head ref: ${{ github.event.pull_request.head.ref }}"
-          echo "Is merged: ${{ github.event.pull_request.merged }}"
-          echo "Created: ${{ github.event.created }}"
-          echo "Sender: ${{ github.event.sender.login }}"
-          echo "Repository: ${{ github.repository }}"
-
       - uses: ./.github/actions/set-release-info
         id: release_info
         with:


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes changes to the `queue_release` job in the GitHub Actions workflow configuration file to improve the release process and enhance debugging information.

Improvements to the release process:

* [`.github/workflows/workflow_distribution.yml`](diffhunk://#diff-eadded3b2f326acf5e7f0e7d84f09ce02fe476b9d81433f379417cd5bcc002e2L468-L504): Added `notify_success` to the `needs` array to ensure all checks have passed before proceeding with the release.
* [`.github/workflows/workflow_distribution.yml`](diffhunk://#diff-eadded3b2f326acf5e7f0e7d84f09ce02fe476b9d81433f379417cd5bcc002e2L468-L504): Updated the conditional `if` statement to check for successful job completion and the specific event action `closed` when a pull request is merged.

Enhancements to debugging information:

* [`.github/workflows/workflow_distribution.yml`](diffhunk://#diff-eadded3b2f326acf5e7f0e7d84f09ce02fe476b9d81433f379417cd5bcc002e2L468-L504): Added additional debug logging to capture the status of individual jobs and the overall job status.