### PR TITLE
bugfix(develop): attempting to ensure create release actually does th…

### DIFF
--- a/.github/actions/create-release/action.yml
+++ b/.github/actions/create-release/action.yml
@@ -40,15 +40,14 @@ runs:
     - name: Extract assets from Docker image
       shell: bash
       run: |
-        # Use the Docker image we already have instead of artifacts
-        DOCKER_TAG=${{ inputs.version }}
-        docker pull cmoe640/dev-environment:${DOCKER_TAG}
+        # Use version from inputs for Docker tag
+        docker pull cmo640/dev-environment:${{ inputs.version }}
         
         # Create release assets directory
         mkdir -p release_assets
         
         # Extract files directly from container
-        docker create --name temp_container cmoe640/dev-environment:${DOCKER_TAG}
+        docker create --name temp_container cmo640/dev-environment:${{ inputs.version }}
         docker cp temp_container:/app/. ./release_assets/
         docker rm temp_container
         
@@ -68,7 +67,7 @@ runs:
           
           ### Docker Image
           ```
-          docker pull cmoe640/dev-environment:${{ inputs.version }}
+          docker pull cmo640/dev-environment:${{ inputs.version }}
           ```
           
           ### SHA256 Checksums


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes changes to the `.github/actions/create-release/action.yml` file to standardize the Docker image tag usage and remove redundant comments.

Standardization of Docker image tag usage:

* [`.github/actions/create-release/action.yml`](diffhunk://#diff-45dad27f90da5e7332a48ea77ace56197e37c80aeadf63cf19403696145856e3L43-R50): Updated the Docker image tag usage to consistently use the version from inputs for pulling and creating the Docker container.

Removal of redundant comments:

* [`.github/actions/create-release/action.yml`](diffhunk://#diff-45dad27f90da5e7332a48ea77ace56197e37c80aeadf63cf19403696145856e3L43-R50): Removed unnecessary comments that were not adding value to the code. [[1]](diffhunk://#diff-45dad27f90da5e7332a48ea77ace56197e37c80aeadf63cf19403696145856e3L43-R50) [[2]](diffhunk://#diff-45dad27f90da5e7332a48ea77ace56197e37c80aeadf63cf19403696145856e3L71-R70)