### PR TITLE
bugfix(develop): ensure that we're not pushing a specific version to …

### DIFF
--- a/.github/actions/create-release/action.yml
+++ b/.github/actions/create-release/action.yml
@@ -1,5 +1,5 @@
 name: 'Create Release'
-description: 'Creates a new release by packaging current codebase and Docker state'
+description: 'Creates a new release with packaged application state'
 
 inputs:
   version:
@@ -35,34 +35,30 @@ runs:
   steps:
     - uses: actions/checkout@v4
       with:
-        fetch-depth: 0  # Full history needed for proper versioning
+        fetch-depth: 0
+        ref: ${{ github.ref }} # Prevents branch deletion
+        clean: false # Preserves local changes
 
-    - name: Extract current Docker image state
+    - name: Package Release Assets
       shell: bash
       run: |
-        # The Docker tag (:beta or :latest) represents our current stable state
-        # We pull this instead of building new to ensure consistency
-        echo "Pulling current Docker state from ${{ inputs.version }}"
-        docker pull cmo640/dev-environment:${{ inputs.version }}
-        
-        # Create staging area for release assets
+        # Create staging area
         mkdir -p release_assets
         
-        # Extract current application state from Docker image
-        # This ensures our release matches exactly what's in production/beta
-        docker create --name temp_container cmo640/dev-environment:${{ inputs.version }}
-        docker cp temp_container:/app/. ./release_assets/
-        docker rm temp_container
+        # Copy application code and configs
+        cp -r distributions startup docs release_assets/
         
-        # Package everything into a distributable archive
-        # This becomes our binary release asset
+        # Include Dockerfile for users who want to build locally
+        cp Dockerfile* release_assets/ 2>/dev/null || true
+        cp docker-compose*.yml release_assets/ 2>/dev/null || true
+        
+        # Package everything
         cd release_assets
         tar -czf ../dev-environment.tar.gz .
         cd ..
         
-        # Generate checksums for verification
+        # Generate checksums
         sha256sum dev-environment.tar.gz > checksum.txt
-        echo "Release archive and checksums created"
 
     - name: Create GitHub Release
       uses: softprops/action-gh-release@v1
@@ -71,25 +67,23 @@ runs:
         name: "${{ inputs.prerelease && 'Beta' || 'Stable' }} Release ${{ inputs.version }}"
         body: |
           ## Release Notes
-          
-          ${{ inputs.release_notes }}
-          
-          ### Changes Included
-          The following changes are included in this release:
-          
           ${{ steps.process.outputs.notes }}
           
           ### Distributions
+          This release includes:
+          - Complete development environment configuration
+          - Docker setup files for containerized usage
+          - Direct deployment scripts
           
-          #### Docker Image
+          ### Installation
           ```bash
-          docker pull cmo640/dev-environment:${{ inputs.version }}
+          # Download and extract
+          curl -LO https://github.com/BA-CalderonMorales/dev-environment/releases/download/${{ inputs.version }}/dev-environment.tar.gz
+          tar xzf dev-environment.tar.gz
+          
+          # Optional: Build Docker container locally
+          docker build -t dev-environment:${{ inputs.version }} .
           ```
-          
-          This image represents the current ${{ inputs.prerelease && 'beta' || 'production' }} state.
-          
-          #### Binary Distribution
-          A standalone environment tarball is available for non-Docker users.
           
           ### Verification
           SHA256 Checksums:
@@ -97,12 +91,12 @@ runs:
           $(cat checksum.txt)
           ```
           
-          ### Additional Notes
-          - Environment: ${{ inputs.prerelease && 'Beta Testing' || 'Production' }}
+          ### Environment Info
+          - Type: ${{ inputs.prerelease && 'Beta' || 'Production' }}
           - Released: $(date -u +"%Y-%m-%d %H:%M:%S UTC")
-          - Branch: ${{ steps.process.outputs.branch }}
+          - Branch: ${{ github.ref_name }}
           
-          For detailed documentation, please see our [Quick Start Guide](docs/QUICK_START.md).
+          For setup instructions, see our [Quick Start Guide](docs/QUICK_START.md).
         
         prerelease: ${{ inputs.prerelease }}
         files: |

--- a/.github/actions/update-docker-tags/action.yml
+++ b/.github/actions/update-docker-tags/action.yml
@@ -2,34 +2,44 @@ name: 'Update Docker Tags'
 description: 'Updates Docker image tags for releases'
 
 inputs:
-  docker_username:
-    description: 'DockerHub username'
-    required: true
-  docker_token:
-    description: 'DockerHub access token'
-    required: true
-  docker_image:
-    description: 'Docker image name'
-    required: true
   version:
-    description: 'Version to tag'
+    description: 'Version to tag (e.g. v1.0.0)'
     required: true
-  docker_tag:
-    description: 'Docker tag (beta/latest)'
+  prerelease:
+    description: 'Whether this is a prerelease'
+    required: true
+  registry_token:  # Renamed for clarity
+    description: 'Container registry access token'
+    required: true
+  registry_username:  # Renamed for clarity
+    description: 'Container registry username'
     required: true
 
 runs:
-  using: composite
+  using: "composite"
   steps:
-    - shell: bash
+    - name: Login to Container Registry
+      shell: bash
       run: |
-        echo "${{ inputs.docker_token }}" | docker login -u "${{ inputs.docker_username }}" --password-stdin
+        echo "${{ inputs.registry_token }}" | \
+        docker login -u "${{ inputs.registry_username }}" --password-stdin
         
-        # Pull current image and update tag
-        docker pull ${{ inputs.docker_image }}:${{ inputs.docker_tag }}
-        docker tag ${{ inputs.docker_image }}:${{ inputs.docker_tag }} ${{ inputs.docker_image }}:${{ inputs.version }}
-        docker push ${{ inputs.docker_image }}:${{ inputs.version }}
+        # Export for subsequent steps
+        echo "DOCKER_TAG=${{ inputs.prerelease && 'beta' || 'latest' }}" >> $GITHUB_ENV
+        echo "VERSION=${{ inputs.version }}" >> $GITHUB_ENV
         
-        # Update branch-specific tag (beta or latest)
-        docker tag ${{ inputs.docker_image }}:${{ inputs.version }} ${{ inputs.docker_image }}:${{ inputs.docker_tag }}
-        docker push ${{ inputs.docker_image }}:${{ inputs.docker_tag }}
+    - name: Update Image Tags
+      shell: bash
+      run: |
+        set -e # Exit on any error
+        
+        IMAGE_NAME="cmo640/dev-environment"
+        
+        echo "Tagging for version ${VERSION}"
+        
+        # Create release-specific version tag from existing image
+        docker tag ${IMAGE_NAME}:${DOCKER_TAG} ${IMAGE_NAME}:${VERSION}
+        docker push ${IMAGE_NAME}:${VERSION}
+        
+        # Update status in GH Actions log
+        echo "✓ Tagged and pushed version: ${VERSION}"

--- a/.github/workflows/workflow_create_release.yml
+++ b/.github/workflows/workflow_create_release.yml
@@ -158,6 +158,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ github.ref }}
+          clean: false
 
       - name: Create Release
         uses: ./.github/actions/create-release
@@ -172,14 +174,14 @@ jobs:
           bot_name: ${{ secrets.BOT_NAME }}
           bot_domain: ${{ secrets.BOT_DOMAIN }}
 
-      - name: Update Docker Tags
+      - name: Update Docker Tags  # Re-add this step
+        if: success()  # Only run if release creation succeeded
         uses: ./.github/actions/update-docker-tags
         with:
-          docker_username: ${{ secrets.DOCKERHUB_USERNAME }}
-          docker_token: ${{ secrets.DOCKERHUB_TOKEN }}
-          docker_image: ${{ env.DOCKER_IMAGE }}
           version: ${{ needs.process_queue.outputs.version }}
-          docker_tag: ${{ contains(needs.process_queue.outputs.branch, 'beta') && 'beta' || 'latest' }}
+          prerelease: ${{ needs.process_queue.outputs.prerelease }}
+          registry_token: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry_username: ${{ secrets.DOCKERHUB_USERNAME }}
 
   #####################################################################
   # Handle Failure


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes significant changes to the GitHub Actions workflows for creating releases and updating Docker tags. The changes aim to improve the release process, enhance clarity, and ensure consistency.

Improvements to the release creation process:

* [`.github/actions/create-release/action.yml`](diffhunk://#diff-45dad27f90da5e7332a48ea77ace56197e37c80aeadf63cf19403696145856e3L2-R2): Updated the description to reflect the new release process, added `ref` and `clean` options to the `checkout` step to prevent branch deletion and preserve local changes, and revised the steps to package release assets directly from the application code and configs instead of extracting from a Docker image. [[1]](diffhunk://#diff-45dad27f90da5e7332a48ea77ace56197e37c80aeadf63cf19403696145856e3L2-R2) [[2]](diffhunk://#diff-45dad27f90da5e7332a48ea77ace56197e37c80aeadf63cf19403696145856e3L38-L65) [[3]](diffhunk://#diff-45dad27f90da5e7332a48ea77ace56197e37c80aeadf63cf19403696145856e3L74-R99)

Enhancements to Docker tag updates:

* [`.github/actions/update-docker-tags/action.yml`](diffhunk://#diff-baf3d046ac13b8658e06aac9409e0ed752506f26c9c31ef29a1c76bb8d195480L5-R45): Renamed input parameters for clarity, added steps to log in to the container registry, and updated the process to tag and push Docker images based on the release version.

Workflow adjustments:

* [`.github/workflows/workflow_create_release.yml`](diffhunk://#diff-213841c6ff0152924de2027113e5dbdf47729655e0ef4148115e77c1e634abeeR161-R162): Added `ref` and `clean` options to the `checkout` step, and re-added the `Update Docker Tags` step with conditions to run only if the release creation succeeds. [[1]](diffhunk://#diff-213841c6ff0152924de2027113e5dbdf47729655e0ef4148115e77c1e634abeeR161-R162) [[2]](diffhunk://#diff-213841c6ff0152924de2027113e5dbdf47729655e0ef4148115e77c1e634abeeL175-R184)