### PR TITLE
bugfix(develop): attempting to properly tag a release.

### DIFF
--- a/.github/actions/create-release/action.yml
+++ b/.github/actions/create-release/action.yml
@@ -60,11 +60,24 @@ runs:
         # Generate checksums
         sha256sum dev-environment.tar.gz > checksum.txt
 
+    - name: Validate Version
+      shell: bash
+      run: |
+        VERSION="${{ inputs.version }}"
+        if [[ -z "$VERSION" ]]; then
+          echo "::error::No version provided. Cannot create release without a tag."
+          exit 1
+        fi
+        
+        # Remove 'v' prefix if present for consistency
+        VERSION=${VERSION#v}
+        echo "VALIDATED_VERSION=v${VERSION}" >> $GITHUB_ENV
+
     - name: Create GitHub Release
       uses: softprops/action-gh-release@v1
       with:
-        tag_name: ${{ inputs.version }}
-        name: "${{ inputs.prerelease && 'Beta' || 'Stable' }} Release ${{ inputs.version }}"
+        tag_name: ${{ env.VALIDATED_VERSION }}
+        name: "${{ inputs.prerelease && 'Beta' || 'Stable' }} Release ${{ env.VALIDATED_VERSION }}"
         body: |
           ## Release Notes
           ${{ steps.process.outputs.notes }}
@@ -78,11 +91,11 @@ runs:
           ### Installation
           ```bash
           # Download and extract
-          curl -LO https://github.com/BA-CalderonMorales/dev-environment/releases/download/${{ inputs.version }}/dev-environment.tar.gz
+          curl -LO https://github.com/BA-CalderonMorales/dev-environment/releases/download/${{ env.VALIDATED_VERSION }}/dev-environment.tar.gz
           tar xzf dev-environment.tar.gz
           
           # Optional: Build Docker container locally
-          docker build -t dev-environment:${{ inputs.version }} .
+          docker build -t dev-environment:${{ env.VALIDATED_VERSION }} .
           ```
           
           ### Verification

--- a/.github/workflows/workflow_create_release.yml
+++ b/.github/workflows/workflow_create_release.yml
@@ -155,6 +155,12 @@ jobs:
       needs.process_queue.outputs.can_proceed == 'true'
     runs-on: ubuntu-22.04
     steps:
+      # Add debug step
+      - name: Debug Version Info
+        run: |
+          echo "Version from process_queue: ${{ needs.process_queue.outputs.version }}"
+          echo "Is prerelease: ${{ needs.process_queue.outputs.prerelease }}"
+
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces several changes to the release creation process in the GitHub Actions workflow. The primary focus is on validating the version input and ensuring consistency in version tagging.

Validation and consistency improvements:

* [`.github/actions/create-release/action.yml`](diffhunk://#diff-45dad27f90da5e7332a48ea77ace56197e37c80aeadf63cf19403696145856e3R63-R80): Added a step to validate the version input, ensuring that a version is provided and removing any 'v' prefix for consistency. Updated subsequent steps to use the validated version.
* [`.github/actions/create-release/action.yml`](diffhunk://#diff-45dad27f90da5e7332a48ea77ace56197e37c80aeadf63cf19403696145856e3L81-R98): Updated the download and Docker build commands to use the validated version instead of the raw input version.

Debugging enhancements:

* [`.github/workflows/workflow_create_release.yml`](diffhunk://#diff-213841c6ff0152924de2027113e5dbdf47729655e0ef4148115e77c1e634abeeR158-R163): Added a debug step to output version information from the `process_queue` job, aiding in troubleshooting and ensuring correct version propagation.