### PR TITLE
bugfix(develop): working on queue-release action fix.

### DIFF
--- a/.github/actions/queue-release/action.yml
+++ b/.github/actions/queue-release/action.yml
@@ -8,6 +8,15 @@ inputs:
     required: true
   branch:
     required: true
+  bot_gpg_private_key:
+    required: true
+    description: 'Bot GPG private key for signing'
+  bot_gpg_passphrase:
+    required: true
+    description: 'Bot GPG passphrase'
+  bot_email:
+    required: true
+    description: 'Bot email for git config'
 
 outputs:
   queue_position:
@@ -66,22 +75,53 @@ runs:
         echo "estimated_time=$EST_DAYS days" >> $GITHUB_OUTPUT
         echo "remaining=$((MIN_ITEMS - POSITION))" >> $GITHUB_OUTPUT
 
-    - name: Configure Git
+    - name: Setup GPG
       shell: bash
       run: |
-        git config user.name "GitHub Action Bot"
-        git config user.email "action@github.com"
+        # Create GPG directories with proper permissions
+        mkdir -p ~/.gnupg
+        chmod 700 ~/.gnupg
+        
+        # Import the GPG private key
+        echo "${{ inputs.bot_gpg_private_key }}" | gpg --batch --import
+        
+        # Get the GPG key ID
+        GPG_KEY_ID=$(gpg --list-secret-keys --keyid-format LONG | grep sec | awk '{print $2}' | cut -d'/' -f2)
+        
+        # Configure Git with GPG
+        git config --global user.signingkey "$GPG_KEY_ID"
+        git config --global commit.gpgsign true
+        git config --global user.name "Development Environment Bot"
+        git config --global user.email "${{ inputs.bot_email }}"
+        
+        # Configure GPG agent
+        echo "allow-preset-passphrase" > ~/.gnupg/gpg-agent.conf
+        echo "RELOADAGENT" | gpg-connect-agent
+        
+        # Trust the key ultimately
+        echo -e "5\ny\n" | gpg --command-fd 0 --expert --edit-key "$GPG_KEY_ID" trust
+      env:
+        GNUPGHOME: /home/runner/.gnupg
 
     - name: Sign Commit
       shell: bash
       run: |
+        # Add changes
         git add .github/release_queue/
-        git commit -S -m "📦 Queue release for ${{ inputs.sha }}
+        
+        # Create signed commit
+        git -c gpg.program="$(which gpg)" \
+            -c user.signingkey="$(gpg --list-secret-keys --keyid-format LONG | grep sec | awk '{print $2}' | cut -d'/' -f2)" \
+            commit -S -m "📦 Queue release for ${{ inputs.sha }}
         
         Queue Status:
         - Position: ${{ steps.queue.outputs.position }}
         - Items needed: ${{ steps.queue.outputs.remaining }} more
         - Estimated time: ${{ steps.queue.outputs.estimated_time }}"
+      env:
+        GPG_TTY: $(tty)
+        GNUPGHOME: /home/runner/.gnupg
+        GPG_PASSPHRASE: ${{ inputs.bot_gpg_passphrase }}
 
     - name: Push Changes
       shell: bash

--- a/.github/workflows/workflow_distribution.yml
+++ b/.github/workflows/workflow_distribution.yml
@@ -556,9 +556,11 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           sha: ${{ steps.release_info.outputs.sha }}
           branch: ${{ steps.release_info.outputs.branch }}
+          bot_gpg_private_key: ${{ secrets.BOT_GPG_PRIVATE_KEY }}
+          bot_gpg_passphrase: ${{ secrets.BOT_GPG_PASSPHRASE }}
+          bot_email: ${{ secrets.BOT_EMAIL }}
 
       - uses: ./.github/actions/trigger-release-workflow
-
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           ref: ${{ github.ref }}


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces changes to the GitHub Actions workflow to enable GPG signing of commits by a bot. The modifications include adding new inputs for GPG configuration, setting up GPG during the workflow, and updating the workflow to use these new inputs.

### GPG Configuration:

* [`.github/actions/queue-release/action.yml`](diffhunk://#diff-ddbd959e8c46b3fe846d1ef5843f7f9c8e4ac856922085f7b15f67d075a49fe4R11-R19): Added new inputs for `bot_gpg_private_key`, `bot_gpg_passphrase`, and `bot_email` to the action configuration.

### Workflow Setup:

* [`.github/actions/queue-release/action.yml`](diffhunk://#diff-ddbd959e8c46b3fe846d1ef5843f7f9c8e4ac856922085f7b15f67d075a49fe4L69-R124): Added steps to set up GPG, configure Git with GPG, and sign commits using the bot's GPG key.

### Workflow Inputs:

* [`.github/workflows/workflow_distribution.yml`](diffhunk://#diff-eadded3b2f326acf5e7f0e7d84f09ce02fe476b9d81433f379417cd5bcc002e2R559-L561): Updated the workflow to pass the new GPG-related secrets (`BOT_GPG_PRIVATE_KEY`, `BOT_GPG_PASSPHRASE`, and `BOT_EMAIL`) to the action.