### PR TITLE
bugfix(develop): reverting to previous workflow if condition check.

### DIFF
--- a/.github/workflows/workflow_distribution.yml
+++ b/.github/workflows/workflow_distribution.yml
@@ -516,30 +516,18 @@ jobs:
   #####################################################################
   queue_release:
     runs-on: ubuntu-22.04
-    # Current needs array is correct
-    needs: [validate_branch, e2e_tests, security_scan]
-    # Modified conditions to strictly follow RELEASE_SCHEDULE.md rules
+    needs: [validate_branch, setup_docker, e2e_tests, security_scan, notify_success]
     if: |
-      success() &&
-      (
-        (
-          github.ref == 'refs/heads/beta' && 
-          contains(github.event.head_commit.message, 'Merge pull request') && 
-          contains(github.event.head_commit.message, 'from develop')
-        ) ||
-        (
-          github.ref == 'refs/heads/main' && 
-          contains(github.event.head_commit.message, 'Merge pull request') && 
-          contains(github.event.head_commit.message, 'from beta')
-        ) ||
-        (
-          github.event_name == 'workflow_dispatch' &&
-          (github.ref == 'refs/heads/beta' || github.ref == 'refs/heads/main')
-        )
+      always() && (
+        github.ref == 'refs/heads/beta' ||
+        github.ref == 'refs/heads/main'
       ) &&
-      needs.validate_branch.result == 'success' &&
-      (needs.e2e_tests.result == 'success' || needs.e2e_tests.result == 'skipped') &&
-      (needs.security_scan.result == 'success' || needs.security_scan.result == 'skipped')
+      (
+        github.event_name == 'push' ||
+        github.event_name == 'workflow_dispatch'
+      ) &&
+      !contains(needs.*.result, 'failure') &&
+      !contains(needs.*.result, 'cancelled')
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes changes to the workflow conditions in the `.github/workflows/workflow_distribution.yml` file to streamline the release process and ensure more robust checks.

Improvements to workflow conditions:

* [`.github/workflows/workflow_distribution.yml`](diffhunk://#diff-eadded3b2f326acf5e7f0e7d84f09ce02fe476b9d81433f379417cd5bcc002e2L519-R530): Updated the `needs` array to include `setup_docker` and `notify_success` jobs.
* [`.github/workflows/workflow_distribution.yml`](diffhunk://#diff-eadded3b2f326acf5e7f0e7d84f09ce02fe476b9d81433f379417cd5bcc002e2L519-R530): Simplified the `if` condition to always run on pushes or workflow dispatch events to the `beta` or `main` branches and to check that no required jobs have failed or been cancelled.