### PR TITLE
bugfix(develop): ensuring right name for steps called.

### DIFF
--- a/.github/actions/queue-release/action.yml
+++ b/.github/actions/queue-release/action.yml
@@ -80,7 +80,7 @@ runs:
     - name: Setup GPG
       shell: bash
       working-directory: .github/scripts
-      run: cargo run --bin step_setup_gpg
+      run: cargo run --bin step-setup-gpg  # Fixed hyphen in name
       env:
         INPUT_BOT_GPG_PRIVATE_KEY: ${{ inputs.bot_gpg_private_key }}
         INPUT_BOT_GPG_PASSPHRASE: ${{ inputs.bot_gpg_passphrase }}
@@ -90,7 +90,7 @@ runs:
     - name: Sign Commit
       shell: bash
       working-directory: .github/scripts
-      run: cargo run --bin step_sign_commit
+      run: cargo run --bin step-sign-commit  # Fixed hyphen in name
       env:
         INPUT_SHA: ${{ inputs.sha }}
         INPUT_BOT_GPG_PASSPHRASE: ${{ inputs.bot_gpg_passphrase }}
@@ -102,7 +102,7 @@ runs:
     - name: Create PR
       shell: bash
       working-directory: .github/scripts
-      run: cargo run --bin step_create_pr
+      run: cargo run --bin step-create-pr  # Fixed hyphen in name
       env:
         GITHUB_TOKEN: ${{ inputs.github_token }}
         QUEUE_BRANCH: ${{ steps.setup_queue.outputs.branch }}


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a small change to the `.github/actions/queue-release/action.yml` file. The change fixes hyphens in the names of several steps to ensure consistency and correctness.

* Fixed hyphen in the name of the `step_setup_gpg` binary to `step-setup-gpg`. (`.github/actions/queue-release/action.yml`, [.github/actions/queue-release/action.ymlL83-R83](diffhunk://#diff-ddbd959e8c46b3fe846d1ef5843f7f9c8e4ac856922085f7b15f67d075a49fe4L83-R83))
* Fixed hyphen in the name of the `step_sign_commit` binary to `step-sign-commit`. (`.github/actions/queue-release/action.yml`, [.github/actions/queue-release/action.ymlL93-R93](diffhunk://#diff-ddbd959e8c46b3fe846d1ef5843f7f9c8e4ac856922085f7b15f67d075a49fe4L93-R93))
* Fixed hyphen in the name of the `step_create_pr` binary to `step-create-pr`. (`.github/actions/queue-release/action.yml`, [.github/actions/queue-release/action.ymlL105-R105](diffhunk://#diff-ddbd959e8c46b3fe846d1ef5843f7f9c8e4ac856922085f7b15f67d075a49fe4L105-R105))