### PR TITLE
bugfix(develop): using actual template.

### DIFF
--- a/.github/actions/queue-release/action.yml
+++ b/.github/actions/queue-release/action.yml
@@ -47,7 +47,7 @@ runs:
         cargo run --bin step-debug-inputs
       env:
         INPUT_SHA: ${{ inputs.sha }}
-        INPUT_BRANCH: ${{ inputs.branch }}
+        INPUT_BRANCH: ${{ inputs.inputs.branch }} # Corrected input
         GITHUB_REF: ${{ github.ref }}
         GITHUB_SHA: ${{ github.sha }}
         RUST_LOG: info
@@ -65,7 +65,7 @@ runs:
       run: cargo run --bin step_process_queue
       env:
         INPUT_SHA: ${{ inputs.sha }}
-        INPUT_BRANCH: ${{ inputs.branch }}
+        INPUT_BRANCH: ${{ inputs.inputs.branch }} # Corrected input
         RUST_LOG: info
 
     - name: Run Automated Tests
@@ -83,7 +83,7 @@ runs:
       env:
         GITHUB_TOKEN: ${{ inputs.github_token }}
         QUEUE_BRANCH: ${{ steps.setup_queue.outputs.branch }}
-        INPUT_BRANCH: ${{ inputs.branch }}
+        INPUT_BRANCH: ${{ inputs.inputs.branch }} # Corrected input
         INPUT_SHA: ${{ inputs.sha }}
         QUEUE_POSITION: ${{ steps.process_queue.outputs.position }}
         QUEUE_REMAINING: ${{ steps.process_queue.outputs.remaining }}

--- a/.github/scripts/src/bin/step_create_pr.rs
+++ b/.github/scripts/src/bin/step_create_pr.rs
@@ -1,7 +1,6 @@
 use anyhow::{Context, Result};
 use github_workflow_scripts::{get_logger, init};
 use octocrab::Octocrab;
-use serde_json::Value;
 use std::env;
 
 #[tokio::main]
@@ -63,21 +62,6 @@ async fn main() -> Result<()> {
         )
         .await
         .context("Failed to add labels")?;
-
-    // Auto-approve
-    logger.info("✅ Auto-approving PR...");
-    let _: Value = octocrab.post(
-        format!("/repos/{}/{}/pulls/{}/reviews",
-            owner,
-            repo,
-            new_pr.number),
-        Some(&serde_json::json!({
-            "event": "APPROVE",
-            "body": "Automatically approved by release queue system"
-        })),
-    )
-    .await
-    .context("Failed to approve PR")?;
 
     logger.info("🎉 Pull request workflow completed successfully!");
     Ok(())


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes corrections to the input references in the GitHub Actions workflow file `.github/actions/queue-release/action.yml`. The most important changes involve fixing the `INPUT_BRANCH` environment variable to correctly reference `inputs.inputs.branch`.

Corrections to input references:

* [`.github/actions/queue-release/action.yml`](diffhunk://#diff-ddbd959e8c46b3fe846d1ef5843f7f9c8e4ac856922085f7b15f67d075a49fe4L50-R50): Corrected `INPUT_BRANCH` to reference `inputs.inputs.branch` in three locations within the `runs:` section. [[1]](diffhunk://#diff-ddbd959e8c46b3fe846d1ef5843f7f9c8e4ac856922085f7b15f67d075a49fe4L50-R50) [[2]](diffhunk://#diff-ddbd959e8c46b3fe846d1ef5843f7f9c8e4ac856922085f7b15f67d075a49fe4L68-R68) [[3]](diffhunk://#diff-ddbd959e8c46b3fe846d1ef5843f7f9c8e4ac856922085f7b15f67d075a49fe4L86-R86)