### PR TITLE
bugfix(develop): reverting an oopsie.

### DIFF
--- a/.github/actions/queue-release/action.yml
+++ b/.github/actions/queue-release/action.yml
@@ -41,7 +41,7 @@ runs:
     # Debug inputs to diagnose any issues
     - name: Debug Inputs
       shell: bash
-      run: cargo run --bin step-debug-inputs  # Use hyphenated name as in Cargo.toml
+      run: cargo run --bin step_debug_inputs  # Use snake_case name as in Cargo.toml
       env:
         INPUT_SHA: ${{ inputs.sha }}
         INPUT_BRANCH: ${{ inputs.branch }}
@@ -53,7 +53,7 @@ runs:
       shell: bash
       run: |
         cd ${{ github.workspace }}/.github/scripts
-        cargo run --bin step-queue-release  # Use hyphenated name as in Cargo.toml
+        cargo run --bin step_queue_release  # Use snake_case name as in Cargo.toml
       env:
         INPUT_SHA: ${{ inputs.sha }}
         INPUT_BRANCH: ${{ inputs.branch }}

--- a/.github/scripts/Cargo.toml
+++ b/.github/scripts/Cargo.toml
@@ -7,70 +7,70 @@ description = "Rust scripts for GitHub Actions workflows"
 [lib]
 path = "src/lib.rs"
 
-# Binary targets use hyphenated names (for action compatibility) 
+# Binary targets use snake_case names (for action compatibility) 
 # but reference underscore-based file paths (Rust convention)
 [[bin]]
-name = "step-check-workflow-states"
+name = "step_check_workflow_states"
 path = "src/bin/step_check_workflow_states.rs"
 
 [[bin]]
-name = "step-check-artifacts"
+name = "step_check_artifacts"
 path = "src/bin/step_check_artifacts.rs"
 
 [[bin]]
-name = "step-check-base-image"
+name = "step_check_base_image"
 path = "src/bin/step_check_base_image.rs"
 
 [[bin]]
-name = "step-setup-docker-env"
+name = "step_setup_docker_env"
 path = "src/bin/step_setup_docker_env.rs"
 
 [[bin]]
-name = "step-build-image"
+name = "step_build_image"
 path = "src/bin/step_build_image.rs"
 
 [[bin]]
-name = "step-verify-docker-image"
+name = "step_verify_docker_image"
 path = "src/bin/step_verify_docker_image.rs"
 
 [[bin]]
-name = "step-validate-version"
+name = "step_validate_version"
 path = "src/bin/step_validate_version.rs"
 
 [[bin]]
-name = "step-package-assets"
+name = "step_package_assets"
 path = "src/bin/step_package_assets.rs"
 
 [[bin]]
-name = "step-configure-git"
+name = "step_configure_git"
 path = "src/bin/step_configure_git.rs"
 
 [[bin]]
-name = "step-update-docs"
+name = "step_update_docs"
 path = "src/bin/step_update_docs.rs"
 
 [[bin]]
-name = "step-debug-inputs"
+name = "step_debug_inputs"
 path = "src/bin/step_debug_inputs.rs"
 
 [[bin]]
-name = "step-create-release"
+name = "step_create_release"
 path = "src/bin/step_create_release.rs"
 
 [[bin]]
-name = "step-cache-cleanup"
+name = "step_cache_cleanup"
 path = "src/bin/step_cache_cleanup.rs"
 
 [[bin]]
-name = "step-setup-gpg"
+name = "step_setup_gpg"
 path = "src/bin/step_setup_gpg.rs"
 
 [[bin]]
-name = "step-setup-release-gpg"
+name = "step_setup_release_gpg"
 path = "src/bin/step_setup_release_gpg.rs"
 
 [[bin]]
-name = "step-queue-release"
+name = "step_queue_release"
 path = "src/bin/step_queue_release.rs"
 
 [dependencies]


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes changes to standardize the naming convention of binary targets in the Rust scripts used for GitHub Actions workflows. The most important changes include modifying file names and references from hyphenated to snake_case format for consistency and compatibility.

Changes to naming convention:

* [`.github/actions/queue-release/action.yml`](diffhunk://#diff-ddbd959e8c46b3fe846d1ef5843f7f9c8e4ac856922085f7b15f67d075a49fe4L44-R44): Changed the `run` commands to use snake_case names instead of hyphenated names. [[1]](diffhunk://#diff-ddbd959e8c46b3fe846d1ef5843f7f9c8e4ac856922085f7b15f67d075a49fe4L44-R44) [[2]](diffhunk://#diff-ddbd959e8c46b3fe846d1ef5843f7f9c8e4ac856922085f7b15f67d075a49fe4L56-R56)
* [`.github/scripts/Cargo.toml`](diffhunk://#diff-bea1af1348a6f7ecee8f775157b78ce75f4e0053b9c7737ada8ae1105682337aL10-R73): Updated the binary target names from hyphenated to snake_case format to match Rust conventions and ensure compatibility.