### PR TITLE
bugfix(develop): attempting to force all jobs: manual execution

### DIFF
--- a/.github/workflows/workflow_create_release.yml
+++ b/.github/workflows/workflow_create_release.yml
@@ -82,10 +82,10 @@ jobs:
   #####################################################################
   process_queue:
     needs: branch_check
+    # Modified to always run for manual triggers on allowed branches
     if: |
-      github.event_name == 'workflow_dispatch' || 
-      github.event_name == 'schedule' && 
-      needs.branch_check.outputs.allowed == 'true'
+      (github.event_name == 'workflow_dispatch' && needs.branch_check.outputs.allowed == 'true') || 
+      (github.event_name == 'schedule' && needs.branch_check.outputs.allowed == 'true')
     runs-on: ubuntu-22.04
     outputs:
       sha: ${{ steps.action.outputs.sha }}
@@ -184,10 +184,10 @@ jobs:
   #####################################################################
   create_release:
     needs: [branch_check, process_queue, determine_version, validate_gpg]
+    # Modified to always run for manual triggers on allowed branches
     if: |
-      github.event_name == 'workflow_dispatch' && needs.process_queue.outputs.can_proceed == 'true' ||
-      needs.branch_check.outputs.allowed == 'true' &&
-      needs.process_queue.outputs.can_proceed == 'true'
+      (github.event_name == 'workflow_dispatch' && needs.branch_check.outputs.allowed == 'true') ||
+      (github.event_name == 'schedule' && needs.branch_check.outputs.allowed == 'true' && needs.process_queue.outputs.can_proceed == 'true')
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION

# Pull Request

## Description

This pull request includes changes to the `.github/workflows/workflow_create_release.yml` file to modify the conditions under which certain jobs run. These changes ensure that jobs will always run for manual triggers on allowed branches.

Changes to job conditions:

* [`jobs.process_queue`](diffhunk://#diff-213841c6ff0152924de2027113e5dbdf47729655e0ef4148115e77c1e634abeeR85-R88): Modified the `if` condition to ensure the job runs for manual triggers (`workflow_dispatch`) on allowed branches.
* [`jobs.create_release`](diffhunk://#diff-213841c6ff0152924de2027113e5dbdf47729655e0ef4148115e77c1e634abeeR187-R190): Adjusted the `if` condition to ensure the job runs for manual triggers (`workflow_dispatch`) on allowed branches and includes an additional check for the `schedule` event.