### PR TITLE
bugfix(develop): utilizing dtolnay/rust-toolchain and building releas…

### DIFF
--- a/.github/actions/queue-release/action.yml
+++ b/.github/actions/queue-release/action.yml
@@ -32,11 +32,14 @@ outputs:
 runs:
   using: 'composite'
   steps:
-    - name: Set up Rust
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        override: true
+    - name: Setup Rust
+      uses: dtolnay/rust-toolchain@stable
+
+    - name: Build workflow scripts
+      shell: bash
+      run: |
+        cd .github/scripts
+        cargo build --release
 
     # Debug inputs to diagnose any issues
     - name: Debug Inputs


### PR DESCRIPTION
# Pull Request

## Description
Found out that we're not building the release module prior to utilizing a bin script. Could be why queue-release is not working. Damn you, ai.