### PR TITLE
bugfix(develop): using right directory prior to calling rust script.

### DIFF
--- a/.github/actions/queue-release/action.yml
+++ b/.github/actions/queue-release/action.yml
@@ -44,7 +44,9 @@ runs:
     # Debug inputs to diagnose any issues
     - name: Debug Inputs
       shell: bash
-      run: cargo run --bin step_debug_inputs  # Use snake_case name as in Cargo.toml
+      run: |
+        cd ${{ github.workspace }}/.github/scripts
+        cargo run --bin step_debug_inputs  # Use snake_case name as in Cargo.toml
       env:
         INPUT_SHA: ${{ inputs.sha }}
         INPUT_BRANCH: ${{ inputs.branch }}


### PR DESCRIPTION
# Pull Request

## Description
Annoying that all it was is the fact that we weren't in the right directory. AI striking again. It was going to send me on a witch hunt to determine why the script wasn't getting called when it "broke down the problem" locally for me.