### PR TITLE
Develop

### DIFF
--- a/.github/actions/create-release/action.yml
+++ b/.github/actions/create-release/action.yml
@@ -56,32 +56,36 @@ runs:
     - name: Validate Version
       shell: bash
       run: |
-        if [[ -z "${{ inputs.version }}" ]]; then
+        VERSION="${{ inputs.version }}"
+        if [[ -z "$VERSION" ]]; then
           echo "::error::Version input is empty. Please provide a valid version."
-          exit 1
+          echo "Falling back to default version"
+          VERSION="beta-v0.0.1"
         fi
-        echo "Using version: ${{ inputs.version }}"
+        echo "Using version: $VERSION"
+        echo "version=$VERSION" >> $GITHUB_ENV  # Make it available to all steps
 
     # Check if release exists first
     - name: Check if release exists
       id: check_release
       shell: bash
       run: |
-        echo "Checking for existing tag ${{ inputs.version }}..."
-        if git rev-parse -q --verify "refs/tags/${{ inputs.version }}" >/dev/null; then
+        VERSION="${{ env.version }}"
+        echo "Checking for existing tag $VERSION..."
+        if git rev-parse -q --verify "refs/tags/$VERSION" >/dev/null; then
           echo "Tag already exists"
           echo "exists=true" >> $GITHUB_OUTPUT
 
           # Check if a GitHub release exists for this tag
-          if gh release view "${{ inputs.version }}" &>/dev/null; then
-            echo "GitHub release for tag ${{ inputs.version }} already exists"
+          if gh release view "$VERSION" &>/dev/null; then
+            echo "GitHub release for tag $VERSION already exists"
             echo "release_exists=true" >> $GITHUB_OUTPUT
             
             # Get the release URL for output
-            release_url="https://github.com/$GITHUB_REPOSITORY/releases/tag/${{ inputs.version }}"
+            release_url="https://github.com/$GITHUB_REPOSITORY/releases/tag/$VERSION"
             echo "release_url=$release_url" >> $GITHUB_OUTPUT
           else
-            echo "GitHub release does not exist yet for tag ${{ inputs.version }}"
+            echo "GitHub release does not exist yet for tag $VERSION"
             echo "release_exists=false" >> $GITHUB_OUTPUT
           fi
         else
@@ -128,7 +132,7 @@ runs:
       shell: bash
       run: ${{ github.workspace }}/.github/scripts/target/debug/step_create_release
       env:
-        INPUT_VERSION: ${{ inputs.version }}
+        INPUT_VERSION: ${{ env.version }}
         INPUT_PRERELEASE: ${{ inputs.prerelease }}
         INPUT_RELEASE_SHA: ${{ inputs.release_sha }}
         INPUT_GITHUB_TOKEN: ${{ inputs.github_token }}

--- a/.github/actions/version-determiner/action.yml
+++ b/.github/actions/version-determiner/action.yml
@@ -25,7 +25,18 @@ runs:
       id: set_version
       shell: bash
       run: |
+        # Ensure we get a valid default version from environment
+        default_version="${{ env.INITIAL_VERSION }}"
+        if [[ -z "$default_version" ]]; then
+          default_version="beta-v0.0.1"
+        fi
+        
         latest_tag="${{ steps.get_latest_tag.outputs.latest_tag }}"
+        if [[ -z "$latest_tag" ]]; then
+          latest_tag="$default_version"
+          echo "No latest tag found, using default: $latest_tag"
+        fi
+        
         current_branch=$(git rev-parse --abbrev-ref HEAD)
         
         # Get source branch from input or current branch

--- a/.github/workflows/workflow_create_release.yml
+++ b/.github/workflows/workflow_create_release.yml
@@ -193,22 +193,33 @@ jobs:
       (github.event_name == 'schedule' && needs.branch_check.outputs.allowed == 'true' && needs.process_queue.outputs.can_proceed == 'true')
     runs-on: ubuntu-22.04
     outputs:
-      release_url: ${{ steps.create_release_action.outputs.release_url }}
-      version: ${{ needs.determine_version.outputs.new_version }}
+      release_url: ${{ steps.create_release_action.outputs.release_url || steps.skipped_release.outputs.release_url || '' }}
+      version: ${{ steps.version_check.outputs.use_version || needs.determine_version.outputs.new_version || env.INITIAL_VERSION }}
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}  # Ensure token has right permissions
 
-      - name: Create VERSION file
+      # Ensure we have a valid version
+      - name: Set Version
+        id: set_version
         run: |
-          echo "${{ needs.determine_version.outputs.new_version }}" > VERSION
+          # Use the determined version or fall back to initial version
+          VERSION="${{ needs.determine_version.outputs.new_version }}"
+          if [[ -z "$VERSION" ]]; then
+            VERSION="${{ env.INITIAL_VERSION }}"
+            echo "::warning::No version determined, using default: $VERSION"
+          fi
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "$VERSION" > VERSION
 
       # Debug step to check version output
       - name: Debug Version Output
         id: debug
         run: |
+          VERSION="${{ steps.set_version.outputs.version }}"
+          echo "Using version: $VERSION"
           echo "Determined version: ${{ needs.determine_version.outputs.new_version }}"
           echo "Is beta: ${{ needs.determine_version.outputs.is_beta }}"
           echo "Process queue version: ${{ needs.process_queue.outputs.version }}"
@@ -216,13 +227,13 @@ jobs:
           cat VERSION
           
           # Check if a release already exists for this version
-          echo "Checking if release for version ${{ needs.determine_version.outputs.new_version }} exists..."
-          if gh release view "${{ needs.determine_version.outputs.new_version }}" &>/dev/null; then
+          echo "Checking if release for version $VERSION exists..."
+          if gh release view "$VERSION" &>/dev/null; then
             echo "release_exists=true" >> $GITHUB_OUTPUT
-            echo "⚠️ Release for version ${{ needs.determine_version.outputs.new_version }} already exists"
+            echo "⚠️ Release for version $VERSION already exists"
           else
             echo "release_exists=false" >> $GITHUB_OUTPUT
-            echo "✅ No existing release found for ${{ needs.determine_version.outputs.new_version }}"
+            echo "✅ No existing release found for $VERSION"
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -231,6 +242,9 @@ jobs:
       - name: Check Conflicts and Prepare Version
         id: version_check
         run: |
+          BASE_VERSION="${{ steps.set_version.outputs.version }}"
+          USE_VERSION="$BASE_VERSION"  # Default to base version
+          
           if [[ "${{ steps.debug.outputs.release_exists }}" == "true" ]]; then
             echo "Existing release found. Checking if we need to create a new release..."
             
@@ -247,25 +261,30 @@ jobs:
                 major="${BASH_REMATCH[1]}"
                 minor="${BASH_REMATCH[2]}"
                 fix=$((BASH_REMATCH[3] + 1))
-                new_version="beta-v${major}.${minor}.${fix}"
-                echo "Incremented version: $new_version"
-                echo "use_version=$new_version" >> $GITHUB_OUTPUT
+                USE_VERSION="beta-v${major}.${minor}.${fix}"
+                echo "Incremented version: $USE_VERSION"
                 echo "should_create=true" >> $GITHUB_OUTPUT
               else
                 echo "Could not parse latest beta tag or no beta tag exists"
-                echo "use_version=${{ needs.determine_version.outputs.new_version }}" >> $GITHUB_OUTPUT
                 echo "should_create=false" >> $GITHUB_OUTPUT
               fi
             else
               # For main branch or other branches, don't create a new release
-              echo "use_version=${{ needs.determine_version.outputs.new_version }}" >> $GITHUB_OUTPUT
               echo "should_create=false" >> $GITHUB_OUTPUT
             fi
           else
             # No existing release, proceed normally
-            echo "use_version=${{ needs.determine_version.outputs.new_version }}" >> $GITHUB_OUTPUT
             echo "should_create=true" >> $GITHUB_OUTPUT
           fi
+          
+          # Validate version
+          if [[ -z "$USE_VERSION" ]]; then
+            echo "::warning::No valid version available, using default"
+            USE_VERSION="${{ env.INITIAL_VERSION }}"
+          fi
+          
+          echo "use_version=$USE_VERSION" >> $GITHUB_OUTPUT
+          echo "Using final version: $USE_VERSION"
 
       - name: Create Release
         id: create_release_action
@@ -288,8 +307,9 @@ jobs:
       - name: Set Output for Skipped Release
         if: steps.version_check.outputs.should_create != 'true'
         run: |
-          echo "Skipping release creation for version ${{ steps.version_check.outputs.use_version }}"
-          release_url="https://github.com/$GITHUB_REPOSITORY/releases/tag/${{ steps.version_check.outputs.use_version }}"
+          VERSION="${{ steps.version_check.outputs.use_version }}"
+          echo "Skipping release creation for version $VERSION"
+          release_url="https://github.com/$GITHUB_REPOSITORY/releases/tag/$VERSION"
           echo "release_url=$release_url" >> $GITHUB_OUTPUT
         id: skipped_release
 


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes several changes to the GitHub Actions workflow configuration files to improve the release process and add new functionality. The most important changes include updating the branch handling logic, installing the GitHub CLI directly within the action, and modifying the workflow paths and triggers.

### Improvements to release process:

* [`.github/actions/process-release-queue-job/action.yml`](diffhunk://#diff-f640ae7acdb4536f3fbdc3f78f3fe107d9c1743a9c5999b79582d3cfc73c74f3L33-R33): Updated the branch handling logic to use the output from the new `branch_setup` step instead of `inputs.source_branch`. This ensures that the branch information is validated and set correctly before proceeding with other steps. [[1]](diffhunk://#diff-f640ae7acdb4536f3fbdc3f78f3fe107d9c1743a9c5999b79582d3cfc73c74f3L33-R33) [[2]](diffhunk://#diff-f640ae7acdb4536f3fbdc3f78f3fe107d9c1743a9c5999b79582d3cfc73c74f3R51-R108) [[3]](diffhunk://#diff-f640ae7acdb4536f3fbdc3f78f3fe107d9c1743a9c5999b79582d3cfc73c74f3L97-R140) [[4]](diffhunk://#diff-f640ae7acdb4536f3fbdc3f78f3fe107d9c1743a9c5999b79582d3cfc73c74f3L224-R262)

### Installation of GitHub CLI:

* [`.github/actions/process-release-queue-job/action.yml`](diffhunk://#diff-f640ae7acdb4536f3fbdc3f78f3fe107d9c1743a9c5999b79582d3cfc73c74f3R51-R108): Added a new step to install the GitHub CLI directly within the action. This ensures that the CLI is available for subsequent steps without needing to rely on pre-installed software.

### Workflow paths and triggers:

* [`.github/workflows/workflow_distribution.yml`](diffhunk://#diff-eadded3b2f326acf5e7f0e7d84f09ce02fe476b9d81433f379417cd5bcc002e2R17-L39): Added a new path pattern for 'security/*' and removed the `pull_request` trigger along with its associated paths and branches. This simplifies the workflow configuration and focuses on specific paths and branches.

* [`.github/workflows/workflow_create_release.yml`](diffhunk://#diff-213841c6ff0152924de2027113e5dbdf47729655e0ef4148115e77c1e634abeeL160-L167): Removed the step to install the GitHub CLI, as it is now handled directly within the `process-release-queue-job` action.