### PR TITLE
consolidatting logic in action create-release.

### DIFF
--- a/.github/actions/create-release/action.yml
+++ b/.github/actions/create-release/action.yml
@@ -1,10 +1,18 @@
 name: 'Create GitHub Release'
-description: 'Creates a GitHub release with optional signing'
+description: 'Creates a GitHub release with optional signing and branch-specific version determination'
 
 inputs:
   version:
-    description: 'Version to release (tag name)'
+    description: 'Version to release (tag name) or "auto" for automatic determination'
+    required: false
+    default: 'auto'
+  source_branch:
+    description: 'Source branch for versioning (beta or main)'
     required: true
+  initial_version:
+    description: 'Initial version to use if no tags exist'
+    required: false
+    default: 'beta-v0.0.1'
   prerelease:
     description: 'Whether this is a prerelease'
     required: false
@@ -48,22 +56,84 @@ outputs:
   release_url:
     description: 'URL of the created release'
     value: ${{ steps.create_release.outputs.release_url }}
+  version:
+    description: 'The final version used for the release'
+    value: ${{ steps.determine_version.outputs.use_version }}
 
 runs:
   using: 'composite'
   steps:
-    # Validate version input before proceeding
-    - name: Validate Version
+    - name: Checkout Repository
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Determine Release Version
+      id: determine_version
       shell: bash
       run: |
-        VERSION="${{ inputs.version }}"
-        if [[ -z "$VERSION" ]]; then
-          echo "::error::Version input is empty. Please provide a valid version."
-          echo "Falling back to default version"
-          VERSION="beta-v0.0.1"
+        BRANCH="${{ inputs.source_branch }}"
+        echo "Source branch: $BRANCH"
+        if [[ "$BRANCH" == "beta" ]]; then
+          PREFIX="beta-v"
+        elif [[ "$BRANCH" == "main" ]]; then
+          PREFIX="stable-v"
+        else
+          echo "::error::Invalid branch: $BRANCH. Must be 'beta' or 'main'"
+          exit 1
         fi
-        echo "Using version: $VERSION"
-        echo "version=$VERSION" >> $GITHUB_ENV  # Make it available to all steps
+
+        # Auto-determine version if requested
+        if [[ "${{ inputs.version }}" == "auto" ]]; then
+          git fetch --tags
+          # For main branch, only match stable tags; for beta, match beta tags
+          LATEST=$(git tag -l "${PREFIX}*" | sort -V | tail -n 1)
+          if [[ -n "$LATEST" ]]; then
+            echo "Latest tag ($PREFIX): $LATEST"
+            if [[ "$LATEST" =~ ${PREFIX}([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
+              major="${BASH_REMATCH[1]}"
+              minor="${BASH_REMATCH[2]}"
+              patch="${BASH_REMATCH[3]}"
+              patch=$((patch + 1))
+              USE_VERSION="${PREFIX}${major}.${minor}.${patch}"
+              echo "Incremented version: $USE_VERSION"
+            else
+              echo "::warning::Could not parse tag $LATEST; falling back to initial version"
+              USE_VERSION="${{ inputs.initial_version }}"
+              # For main, force stable prefix replacement if needed
+              if [[ "$BRANCH" == "main" ]]; then
+                USE_VERSION="${USE_VERSION/beta-v/stable-v}"
+              fi
+            fi
+          else
+            # For main branch: if no stable tag, try deriving from latest beta tag
+            if [[ "$BRANCH" == "main" ]]; then
+              LATEST_BETA=$(git tag -l "beta-v*" | sort -V | tail -n 1)
+              if [[ -n "$LATEST_BETA" && "$LATEST_BETA" =~ beta-v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
+                major="${BASH_REMATCH[1]}"
+                minor="${BASH_REMATCH[2]}"
+                patch="${BASH_REMATCH[3]}"
+                USE_VERSION="stable-v${major}.${minor}.$((patch+1))"
+                echo "Derived stable version from beta tag: $USE_VERSION"
+              else
+                USE_VERSION="${{ inputs.initial_version/beta-v/stable-v}}"
+                echo "No beta tag found; using default stable version: $USE_VERSION"
+              fi
+            else
+              USE_VERSION="${{ inputs.initial_version }}"
+              echo "No tag found; using default version: $USE_VERSION"
+            fi
+          fi
+        else
+          USE_VERSION="${{ inputs.version }}"
+          if [[ "$BRANCH" == "main" && ! "$USE_VERSION" =~ ^stable-v ]]; then
+            USE_VERSION="${USE_VERSION/beta-v/stable-v}"
+            echo "Adjusted provided version for main branch: $USE_VERSION"
+          fi
+        fi
+
+        echo "Determined release version: $USE_VERSION"
+        echo "use_version=$USE_VERSION" >> $GITHUB_OUTPUT
 
     # Check if release exists first
     - name: Check if release exists
@@ -126,16 +196,31 @@ runs:
         fi
 
     # Run the release creation script
-    - name: Create GitHub Release
-      if: steps.check_release.outputs.release_exists != 'true'
+    - name: Check if release exists and create if needed
       id: create_release
       shell: bash
-      run: ${{ github.workspace }}/.github/scripts/target/debug/step_create_release
+      run: |
+        # If the release exists, the script (or gh cli) will set a non-zero exit code (or we can test here)
+        if gh release view "$use_version" &>/dev/null; then
+          echo "Release for version $use_version already exists."
+          exit 0
+        else
+          # Call our release creation script. This script is assumed to capture the full releasing process.
+          echo "Creating release for version $use_version..."
+          ${{ github.workspace }}/.github/scripts/target/debug/step_create_release
+        fi
       env:
-        INPUT_VERSION: ${{ env.version }}
-        INPUT_PRERELEASE: ${{ inputs.prerelease }}
+        use_version: ${{ steps.determine_version.outputs.use_version }}
         INPUT_RELEASE_SHA: ${{ inputs.release_sha }}
         INPUT_GITHUB_TOKEN: ${{ inputs.github_token }}
+        INPUT_PRERELEASE: ${{ inputs.prerelease }}
         INPUT_DRAFT: ${{ inputs.draft }}
         INPUT_GENERATE_RELEASE_NOTES: ${{ inputs.generate_release_notes }}
         INPUT_ALLOW_UNSIGNED: ${{ inputs.allow_unsigned }}
+
+    # Set final output
+    - name: Set Version Output
+      shell: bash
+      run: |
+        echo "Final release version: ${{ steps.determine_version.outputs.use_version }}"
+        echo "version=${{ steps.determine_version.outputs.use_version }}" >> $GITHUB_OUTPUT

--- a/.github/workflows/workflow_create_release.yml
+++ b/.github/workflows/workflow_create_release.yml
@@ -179,112 +179,26 @@ jobs:
   #####################################################################
   create_release:
     needs: [branch_check, determine_version, validate_gpg, process_queue]
-    # Modified to always run for manual triggers on allowed branches
     if: |
       (github.event_name == 'workflow_dispatch' && needs.branch_check.outputs.allowed == 'true') ||
       (github.event_name == 'schedule' && needs.branch_check.outputs.allowed == 'true' && needs.process_queue.outputs.can_proceed == 'true')
     runs-on: ubuntu-22.04
     outputs:
-      release_url: ${{ steps.create_release_action.outputs.release_url || steps.skipped_release.outputs.release_url || '' }}
-      version: ${{ steps.version_check.outputs.use_version || needs.determine_version.outputs.new_version || env.INITIAL_VERSION }}
+      release_url: ${{ steps.create_release_action.outputs.release_url || '' }}
+      version: ${{ steps.create_release_action.outputs.version || env.INITIAL_VERSION }}
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}  # Ensure token has right permissions
-
-      # Ensure we have a valid version
-      - name: Set Version
-        id: set_version
-        run: |
-          # Use the determined version or fall back to initial version
-          VERSION="${{ needs.determine_version.outputs.new_version }}"
-          if [[ -z "$VERSION" ]]; then
-            VERSION="${{ env.INITIAL_VERSION }}"
-            echo "::warning::No version determined, using default: $VERSION"
-          fi
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "$VERSION" > VERSION
-
-      # Debug step to check version output
-      - name: Debug Version Output
-        id: debug
-        run: |
-          VERSION="${{ steps.set_version.outputs.version }}"
-          echo "Using version: $VERSION"
-          echo "Determined version: ${{ needs.determine_version.outputs.new_version }}"
-          echo "Is beta: ${{ needs.determine_version.outputs.is_beta }}"
-          echo "Process queue version: ${{ needs.process_queue.outputs.version }}"
-          echo "VERSION file content:"
-          cat VERSION
-          
-          # Check if a release already exists for this version
-          echo "Checking if release for version $VERSION exists..."
-          if gh release view "$VERSION" &>/dev/null; then
-            echo "release_exists=true" >> $GITHUB_OUTPUT
-            echo "⚠️ Release for version $VERSION already exists"
-          else
-            echo "release_exists=false" >> $GITHUB_OUTPUT
-            echo "✅ No existing release found for $VERSION"
-          fi
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      # Check for conflicting releases and decide whether to create a new one
-      - name: Check Conflicts and Prepare Version
-        id: version_check
-        run: |
-          BASE_VERSION="${{ steps.set_version.outputs.version }}"
-          USE_VERSION="$BASE_VERSION"  # Default to base version
-          
-          if [[ "${{ steps.debug.outputs.release_exists }}" == "true" ]]; then
-            echo "Existing release found. Checking if we need to create a new release..."
-            
-            # Access latest tags
-            git fetch --tags
-            
-            # If we're on beta branch, try to increment version
-            if [[ "${{ needs.branch_check.outputs.branch }}" == "beta" ]]; then
-              echo "On beta branch, will create a new beta version with a fix increment"
-              latest_tag=$(git describe --tags --abbrev=0 --match "beta-v*" 2>/dev/null)
-              
-              if [[ -n "$latest_tag" && "$latest_tag" =~ beta-v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-                # Increment the fix (c) version
-                major="${BASH_REMATCH[1]}"
-                minor="${BASH_REMATCH[2]}"
-                fix=$((BASH_REMATCH[3] + 1))
-                USE_VERSION="beta-v${major}.${minor}.${fix}"
-                echo "Incremented version: $USE_VERSION"
-                echo "should_create=true" >> $GITHUB_OUTPUT
-              else
-                echo "Could not parse latest beta tag or no beta tag exists"
-                echo "should_create=false" >> $GITHUB_OUTPUT
-              fi
-            else
-              # For main branch or other branches, don't create a new release
-              echo "should_create=false" >> $GITHUB_OUTPUT
-            fi
-          else
-            # No existing release, proceed normally
-            echo "should_create=true" >> $GITHUB_OUTPUT
-          fi
-          
-          # Validate version
-          if [[ -z "$USE_VERSION" ]]; then
-            echo "::warning::No valid version available, using default"
-            USE_VERSION="${{ env.INITIAL_VERSION }}"
-          fi
-          
-          echo "use_version=$USE_VERSION" >> $GITHUB_OUTPUT
-          echo "Using final version: $USE_VERSION"
-
-      - name: Create Release
+          token: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Create Release via Action
         id: create_release_action
         uses: ./.github/actions/create-release
-        if: steps.version_check.outputs.should_create == 'true'
         with:
-          # Use the version that was determined or adjusted
-          version: ${{ steps.version_check.outputs.use_version }}
+          version: auto
+          source_branch: ${{ github.event.inputs.source_branch }}
+          initial_version: ${{ env.INITIAL_VERSION }}
           prerelease: ${{ needs.determine_version.outputs.is_beta || 'true' }}
           release_sha: ${{ needs.process_queue.outputs.sha }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -294,16 +208,7 @@ jobs:
           bot_name: ${{ secrets.BOT_NAME || 'GitHub Actions' }}
           allow_unsigned: ${{ github.event.inputs.allow_unsigned || 'true' }}
           generate_release_notes: 'true'
-          skip_if_exists: 'true'  # Skip if the tag already exists
-
-      - name: Set Output for Skipped Release
-        if: steps.version_check.outputs.should_create != 'true'
-        run: |
-          VERSION="${{ steps.version_check.outputs.use_version }}"
-          echo "Skipping release creation for version $VERSION"
-          release_url="https://github.com/$GITHUB_REPOSITORY/releases/tag/$VERSION"
-          echo "release_url=$release_url" >> $GITHUB_OUTPUT
-        id: skipped_release
+          skip_if_exists: 'true'
 
   #####################################################################
   # Handle Failure


### PR DESCRIPTION
# Pull Request

## Description

This pull request enhances the GitHub release creation action by adding branch-specific version determination and automating version management. The changes primarily focus on improving the flexibility and automation of the release process.

### Enhancements to release creation:

* [`.github/actions/create-release/action.yml`](diffhunk://#diff-45dad27f90da5e7332a48ea77ace56197e37c80aeadf63cf19403696145856e3L2-R15): Updated the description to include branch-specific version determination and added new inputs for `source_branch` and `initial_version`. The `version` input is now optional and defaults to "auto".
* [`.github/actions/create-release/action.yml`](diffhunk://#diff-45dad27f90da5e7332a48ea77ace56197e37c80aeadf63cf19403696145856e3R59-R136): Added a new step to determine the release version based on the source branch and existing tags. This step handles both "beta" and "main" branches, with appropriate version prefixing and incrementation.
* [`.github/actions/create-release/action.yml`](diffhunk://#diff-45dad27f90da5e7332a48ea77ace56197e37c80aeadf63cf19403696145856e3L129-R226): Modified the release creation step to check if a release already exists for the determined version and create it if needed.

### Workflow adjustments:

* [`.github/workflows/workflow_create_release.yml`](diffhunk://#diff-213841c6ff0152924de2027113e5dbdf47729655e0ef4148115e77c1e634abeeL182-R201): Simplified the job to create releases by removing redundant steps and integrating the new version determination logic. The workflow now directly uses the `create-release` action with the `auto` version input.
* [`.github/workflows/workflow_create_release.yml`](diffhunk://#diff-213841c6ff0152924de2027113e5dbdf47729655e0ef4148115e77c1e634abeeL297-R211): Removed unnecessary steps that manually checked for existing releases and adjusted versions, relying on the improved `create-release` action instead.