### PR TITLE
Merge pull request #131 from BA-CalderonMorales/beta

### DIFF
--- a/.github/actions/create-release/action.yml
+++ b/.github/actions/create-release/action.yml
@@ -56,32 +56,36 @@ runs:
     - name: Validate Version
       shell: bash
       run: |
-        if [[ -z "${{ inputs.version }}" ]]; then
+        VERSION="${{ inputs.version }}"
+        if [[ -z "$VERSION" ]]; then
           echo "::error::Version input is empty. Please provide a valid version."
-          exit 1
+          echo "Falling back to default version"
+          VERSION="beta-v0.0.1"
         fi
-        echo "Using version: ${{ inputs.version }}"
+        echo "Using version: $VERSION"
+        echo "version=$VERSION" >> $GITHUB_ENV  # Make it available to all steps
 
     # Check if release exists first
     - name: Check if release exists
       id: check_release
       shell: bash
       run: |
-        echo "Checking for existing tag ${{ inputs.version }}..."
-        if git rev-parse -q --verify "refs/tags/${{ inputs.version }}" >/dev/null; then
+        VERSION="${{ env.version }}"
+        echo "Checking for existing tag $VERSION..."
+        if git rev-parse -q --verify "refs/tags/$VERSION" >/dev/null; then
           echo "Tag already exists"
           echo "exists=true" >> $GITHUB_OUTPUT
 
           # Check if a GitHub release exists for this tag
-          if gh release view "${{ inputs.version }}" &>/dev/null; then
-            echo "GitHub release for tag ${{ inputs.version }} already exists"
+          if gh release view "$VERSION" &>/dev/null; then
+            echo "GitHub release for tag $VERSION already exists"
             echo "release_exists=true" >> $GITHUB_OUTPUT
             
             # Get the release URL for output
-            release_url="https://github.com/$GITHUB_REPOSITORY/releases/tag/${{ inputs.version }}"
+            release_url="https://github.com/$GITHUB_REPOSITORY/releases/tag/$VERSION"
             echo "release_url=$release_url" >> $GITHUB_OUTPUT
           else
-            echo "GitHub release does not exist yet for tag ${{ inputs.version }}"
+            echo "GitHub release does not exist yet for tag $VERSION"
             echo "release_exists=false" >> $GITHUB_OUTPUT
           fi
         else
@@ -128,7 +132,7 @@ runs:
       shell: bash
       run: ${{ github.workspace }}/.github/scripts/target/debug/step_create_release
       env:
-        INPUT_VERSION: ${{ inputs.version }}
+        INPUT_VERSION: ${{ env.version }}
         INPUT_PRERELEASE: ${{ inputs.prerelease }}
         INPUT_RELEASE_SHA: ${{ inputs.release_sha }}
         INPUT_GITHUB_TOKEN: ${{ inputs.github_token }}

--- a/.github/actions/version-determiner/action.yml
+++ b/.github/actions/version-determiner/action.yml
@@ -25,7 +25,18 @@ runs:
       id: set_version
       shell: bash
       run: |
+        # Ensure we get a valid default version from environment
+        default_version="${{ env.INITIAL_VERSION }}"
+        if [[ -z "$default_version" ]]; then
+          default_version="beta-v0.0.1"
+        fi
+        
         latest_tag="${{ steps.get_latest_tag.outputs.latest_tag }}"
+        if [[ -z "$latest_tag" ]]; then
+          latest_tag="$default_version"
+          echo "No latest tag found, using default: $latest_tag"
+        fi
+        
         current_branch=$(git rev-parse --abbrev-ref HEAD)
         
         # Get source branch from input or current branch

--- a/.github/workflows/workflow_create_release.yml
+++ b/.github/workflows/workflow_create_release.yml
@@ -193,22 +193,33 @@ jobs:
       (github.event_name == 'schedule' && needs.branch_check.outputs.allowed == 'true' && needs.process_queue.outputs.can_proceed == 'true')
     runs-on: ubuntu-22.04
     outputs:
-      release_url: ${{ steps.create_release_action.outputs.release_url }}
-      version: ${{ needs.determine_version.outputs.new_version }}
+      release_url: ${{ steps.create_release_action.outputs.release_url || steps.skipped_release.outputs.release_url || '' }}
+      version: ${{ steps.version_check.outputs.use_version || needs.determine_version.outputs.new_version || env.INITIAL_VERSION }}
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}  # Ensure token has right permissions
 
-      - name: Create VERSION file
+      # Ensure we have a valid version
+      - name: Set Version
+        id: set_version
         run: |
-          echo "${{ needs.determine_version.outputs.new_version }}" > VERSION
+          # Use the determined version or fall back to initial version
+          VERSION="${{ needs.determine_version.outputs.new_version }}"
+          if [[ -z "$VERSION" ]]; then
+            VERSION="${{ env.INITIAL_VERSION }}"
+            echo "::warning::No version determined, using default: $VERSION"
+          fi
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "$VERSION" > VERSION
 
       # Debug step to check version output
       - name: Debug Version Output
         id: debug
         run: |
+          VERSION="${{ steps.set_version.outputs.version }}"
+          echo "Using version: $VERSION"
           echo "Determined version: ${{ needs.determine_version.outputs.new_version }}"
           echo "Is beta: ${{ needs.determine_version.outputs.is_beta }}"
           echo "Process queue version: ${{ needs.process_queue.outputs.version }}"
@@ -216,13 +227,13 @@ jobs:
           cat VERSION
           
           # Check if a release already exists for this version
-          echo "Checking if release for version ${{ needs.determine_version.outputs.new_version }} exists..."
-          if gh release view "${{ needs.determine_version.outputs.new_version }}" &>/dev/null; then
+          echo "Checking if release for version $VERSION exists..."
+          if gh release view "$VERSION" &>/dev/null; then
             echo "release_exists=true" >> $GITHUB_OUTPUT
-            echo "⚠️ Release for version ${{ needs.determine_version.outputs.new_version }} already exists"
+            echo "⚠️ Release for version $VERSION already exists"
           else
             echo "release_exists=false" >> $GITHUB_OUTPUT
-            echo "✅ No existing release found for ${{ needs.determine_version.outputs.new_version }}"
+            echo "✅ No existing release found for $VERSION"
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -231,6 +242,9 @@ jobs:
       - name: Check Conflicts and Prepare Version
         id: version_check
         run: |
+          BASE_VERSION="${{ steps.set_version.outputs.version }}"
+          USE_VERSION="$BASE_VERSION"  # Default to base version
+          
           if [[ "${{ steps.debug.outputs.release_exists }}" == "true" ]]; then
             echo "Existing release found. Checking if we need to create a new release..."
             
@@ -247,25 +261,30 @@ jobs:
                 major="${BASH_REMATCH[1]}"
                 minor="${BASH_REMATCH[2]}"
                 fix=$((BASH_REMATCH[3] + 1))
-                new_version="beta-v${major}.${minor}.${fix}"
-                echo "Incremented version: $new_version"
-                echo "use_version=$new_version" >> $GITHUB_OUTPUT
+                USE_VERSION="beta-v${major}.${minor}.${fix}"
+                echo "Incremented version: $USE_VERSION"
                 echo "should_create=true" >> $GITHUB_OUTPUT
               else
                 echo "Could not parse latest beta tag or no beta tag exists"
-                echo "use_version=${{ needs.determine_version.outputs.new_version }}" >> $GITHUB_OUTPUT
                 echo "should_create=false" >> $GITHUB_OUTPUT
               fi
             else
               # For main branch or other branches, don't create a new release
-              echo "use_version=${{ needs.determine_version.outputs.new_version }}" >> $GITHUB_OUTPUT
               echo "should_create=false" >> $GITHUB_OUTPUT
             fi
           else
             # No existing release, proceed normally
-            echo "use_version=${{ needs.determine_version.outputs.new_version }}" >> $GITHUB_OUTPUT
             echo "should_create=true" >> $GITHUB_OUTPUT
           fi
+          
+          # Validate version
+          if [[ -z "$USE_VERSION" ]]; then
+            echo "::warning::No valid version available, using default"
+            USE_VERSION="${{ env.INITIAL_VERSION }}"
+          fi
+          
+          echo "use_version=$USE_VERSION" >> $GITHUB_OUTPUT
+          echo "Using final version: $USE_VERSION"
 
       - name: Create Release
         id: create_release_action
@@ -288,8 +307,9 @@ jobs:
       - name: Set Output for Skipped Release
         if: steps.version_check.outputs.should_create != 'true'
         run: |
-          echo "Skipping release creation for version ${{ steps.version_check.outputs.use_version }}"
-          release_url="https://github.com/$GITHUB_REPOSITORY/releases/tag/${{ steps.version_check.outputs.use_version }}"
+          VERSION="${{ steps.version_check.outputs.use_version }}"
+          echo "Skipping release creation for version $VERSION"
+          release_url="https://github.com/$GITHUB_REPOSITORY/releases/tag/$VERSION"
           echo "release_url=$release_url" >> $GITHUB_OUTPUT
         id: skipped_release
 


### PR DESCRIPTION
Merge pull request #127 from BA-CalderonMorales/main# Pull Request

## Description

This pull request introduces several enhancements and refactors to the GitHub Actions workflow for creating releases. The changes focus on automating version determination based on the branch and improving the overall release process.

### Enhancements to version determination and release process:

* [`.github/actions/create-release/action.yml`](diffhunk://#diff-45dad27f90da5e7332a48ea77ace56197e37c80aeadf63cf19403696145856e3L2-R15): Added inputs for `source_branch` and `initial_version`, and updated the `version` input to allow automatic determination. Implemented logic to determine the version based on the branch and existing tags. [[1]](diffhunk://#diff-45dad27f90da5e7332a48ea77ace56197e37c80aeadf63cf19403696145856e3L2-R15) [[2]](diffhunk://#diff-45dad27f90da5e7332a48ea77ace56197e37c80aeadf63cf19403696145856e3R59-R136)
* [`.github/actions/create-release/action.yml`](diffhunk://#diff-45dad27f90da5e7332a48ea77ace56197e37c80aeadf63cf19403696145856e3L129-R226): Added steps to check out the repository, determine the release version, and set the final version output. Updated the release creation step to handle existing releases more gracefully.

### Workflow updates:

* [`.github/workflows/workflow_create_release.yml`](diffhunk://#diff-213841c6ff0152924de2027113e5dbdf47729655e0ef4148115e77c1e634abeeL182-R201): Simplified the workflow by removing redundant steps and using the updated `create-release` action. Updated the job to always run for manual triggers on allowed branches and set the final output version directly from the action. [[1]](diffhunk://#diff-213841c6ff0152924de2027113e5dbdf47729655e0ef4148115e77c1e634abeeL182-R201) [[2]](diffhunk://#diff-213841c6ff0152924de2027113e5dbdf47729655e0ef4148115e77c1e634abeeL297-R211)