### PR TITLE
ensure we're checking against specific branch patterns.

### DIFF
--- a/.github/actions/version-determiner/action.yml
+++ b/.github/actions/version-determiner/action.yml
@@ -4,7 +4,7 @@ description: 'Determines the next version number with prefix support'
 inputs:
   source_branch:
     description: 'Source branch for versioning (beta or main)'
-    required: false
+    required: true
     default: 'beta'
   initial_version:
     description: 'Initial version to use if no tags exist'
@@ -22,6 +22,14 @@ outputs:
 runs:
   using: 'composite'
   steps:
+    # Show diagnostic information about the branch
+    - name: Display branch information
+      shell: bash
+      run: |
+        echo "Source branch: ${{ inputs.source_branch }}"
+        echo "Current ref: ${{ github.ref }}"
+        echo "Repository: ${{ github.repository }}"
+        
     # Ensure Rust scripts are compiled
     - name: Compile Rust scripts
       shell: bash

--- a/.github/workflows/workflow_create_release.yml
+++ b/.github/workflows/workflow_create_release.yml
@@ -94,6 +94,9 @@ jobs:
       
       - id: version_action
         uses: ./.github/actions/version-determiner
+        with:
+          source_branch: ${{ github.event.inputs.source_branch || needs.branch_check.outputs.branch }}
+          initial_version: ${{ env.INITIAL_VERSION }}
 
   #####################################################################
   # Validate GPG Keys


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes several changes to the GitHub Actions workflow, specifically focusing on the `version-determiner` action and the `workflow_create_release.yml` file. The most important changes include making the `source_branch` input required, adding a diagnostic step to display branch information, and updating the workflow to use the new `source_branch` input.

Changes to `version-determiner` action:

* [`.github/actions/version-determiner/action.yml`](diffhunk://#diff-0961b0d83b3846eb8d8d0d21cf7e3ed90d3f1cd57a592cb248229d60e714c52bL7-R7): Made the `source_branch` input required.
* [`.github/actions/version-determiner/action.yml`](diffhunk://#diff-0961b0d83b3846eb8d8d0d21cf7e3ed90d3f1cd57a592cb248229d60e714c52bR25-R32): Added a diagnostic step to display branch information in the action's steps.

Updates to the release workflow:

* [`.github/workflows/workflow_create_release.yml`](diffhunk://#diff-213841c6ff0152924de2027113e5dbdf47729655e0ef4148115e77c1e634abeeR97-R99): Updated the `version-determiner` action to use the new `source_branch` input from the event or previous step output.